### PR TITLE
Comforter uses master as the benchmark branch to compare the converage changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Connects to a comforter instance and help send coverage data to be logged
 
 #### Usage
 `npm install -g comforter-cli`
-`comforter-cli (--path <path-to-lcov-info-file> OR --totalLines <lines> --totalCovered <lines>) --name <project-name> --branch <branch-name> --project <project-id> --commit <sha> --apiKey <key> [--zip <path-to-html-coverage>]`
+`comforter-cli (--path <path-to-lcov-info-file> OR --totalLines <lines> --totalCovered <lines>) --name <project-name> --branch <branch-name> --project <project-id> --commit <sha> [--merge-base <sha>] [--target-branch <branch name>] --apiKey <key> [--zip <path-to-html-coverage>]`
 
 * [x] Accept path to generated coverage html and zip and send to Comforter
 * [ ] Use `npm cli` to avoid running tests in exec, allowing coverage and better testing (see [jshint](https://github.com/jshint/jshint) repo for examples)

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,14 @@ function sendRequest () {
 		data.totalCovered = argv.totalCovered;
 	}
 
+	if (argv['merge-base']) {
+		data.mergeBase = argv['merge-base'];
+	}
+
+	if (argv['target-branch']) {
+		data.targetBranch = argv['target-branch'];
+	}
+
 	var deferred = q.defer();
 
 	// handle lcov file if included
@@ -110,7 +118,8 @@ function sendRequest () {
 		// network failure or other issue with the request
 		.on('error', fail.bind(null, errors.network))
 		.on('fail', fail.bind(null, errors.badRequest));
-	});
+	})
+	.catch(fail.bind(null, errors.badRequest));
 
 }
 
@@ -128,7 +137,7 @@ function handleParams (params) {
 	if (!params.path && !params.totalLines) {
 		fail(errors.missingCoverage);
 	}
-	if (!params.project || !params.branch || !params.commit || !params.host || !params.apiKey) {
+	if (!params.project || !params.branch || !params.commit || !params.host || !params.apiKey || !params.name) {
 		fail(errors.missingRequiredParams);
 	}
 


### PR DESCRIPTION
--target--branch allows you to specify the branch instead. If not included, it defaults to master
--merge--base allows you to specify a commit hash to use instead. If not include
or coverage has no data for the commit, it defaults to --target--branch.

Note: this requires coverage to be updated to use these params.