### PR TITLE
Adds the --merge-request-iid param

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Connects to a comforter instance and help send coverage data to be logged
 
 #### Usage
 `npm install -g comforter-cli`
-`comforter-cli (--path <path-to-lcov-info-file> OR --totalLines <lines> --totalCovered <lines>) --name <project-name> --branch <branch-name> --project <project-id> --commit <sha> [--merge-base <sha>] [--target-branch <branch name>] --apiKey <key> [--zip <path-to-html-coverage>]`
+`comforter-cli (--path <path-to-lcov-info-file> OR --totalLines <lines> --totalCovered <lines>) --name <project-name> --branch <branch-name> --project <project-id> --commit <sha> [--merge-base <sha>] [--target-branch <branch name>] [--merge-request-iid <id>] --apiKey <key> [--zip <path-to-html-coverage>]`
 
 * [x] Accept path to generated coverage html and zip and send to Comforter
 * [ ] Use `npm cli` to avoid running tests in exec, allowing coverage and better testing (see [jshint](https://github.com/jshint/jshint) repo for examples)

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,6 +52,10 @@ function sendRequest () {
 		data.targetBranch = argv['target-branch'];
 	}
 
+	if (argv['merge-request-iid']) {
+		data.mergeRequestIID = argv['merge-request-iid'];
+	}
+
 	var deferred = q.defer();
 
 	// handle lcov file if included


### PR DESCRIPTION
This param can be used to pass the merge request iid to comforter.
This allows comforter to pull the merge-base from gitlab to be used
when comparing the new converage to the old coverage.